### PR TITLE
Document both device addresses

### DIFF
--- a/examples/i2c.toit
+++ b/examples/i2c.toit
@@ -11,7 +11,8 @@ main:
     --sda=gpio.Pin 21
     --scl=gpio.Pin 22
 
-  device := bus.device bme280.I2C_ADDRESS_ALT
+  address := bme280.I2C_ADDRESS // for 0x76, bme280.I2C_ADDRESS_ALT for 0x77
+  device := bus.device address
 
   driver := bme280.Driver device
 

--- a/examples/i2c.toit
+++ b/examples/i2c.toit
@@ -11,7 +11,12 @@ main:
     --sda=gpio.Pin 21
     --scl=gpio.Pin 22
 
-  address := bme280.I2C_ADDRESS // for 0x76, bme280.I2C_ADDRESS_ALT for 0x77
+  // The BME280 can be configured to have one of two different addresses.
+  // - bme280.I2C_ADDRESS, equal to 0x76
+  // - bme280.I2C_ADDRESS_ALT, equal to 0x77
+  // The address is generally chosen by the break-out board.
+  // If the example fails with I2C_READ_FAILED verify that you are using the correct address.
+  address := bme280.I2C_ADDRESS
   device := bus.device address
 
   driver := bme280.Driver device


### PR DESCRIPTION
I got an `I2C_READ_FAILED` when I ran the example and since this is the first time I'm using Toit and a bme280, I thought maybe the hardware is defective. Eventually, I decided to take a look at the driver, only to find out that there are two possible device addresses. I'm not sure why the example uses the alternative address by default, because my bme280 came with 0x76 and requires a jumper to be set to 0x77.

Anyway, I thought it'd be good to mention both device addresses in the example.